### PR TITLE
[Refactor] user 엔터티와 연관관계 매핑 및 공감문 수정 기능 보완

### DIFF
--- a/src/main/java/com/petfarewell/dailylog/entity/DailyLog.java
+++ b/src/main/java/com/petfarewell/dailylog/entity/DailyLog.java
@@ -1,5 +1,6 @@
 package com.petfarewell.dailylog.entity;
 
+import com.petfarewell.auth.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,8 +16,9 @@ public class DailyLog {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(name = "log_date", nullable = false)
     private LocalDate logDate;

--- a/src/main/java/com/petfarewell/dailylog/repository/DailyLogRepository.java
+++ b/src/main/java/com/petfarewell/dailylog/repository/DailyLogRepository.java
@@ -10,11 +10,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DailyLogRepository extends JpaRepository<DailyLog, Long> {
-    long countByUserId(Long userId);
+    long countByUser(User user);
 
-    Optional<DailyLog> findByIdAndUserIdAndDeletedFalse(Long id, Long userId);
+    Optional<DailyLog> findByIdAndUserAndDeletedFalse(Long id, User user);
 
-    List<DailyLog> findByUserIdAndDeletedFalseOrderByLogDateDesc(Long userId);
+    List<DailyLog> findByUserAndDeletedFalseOrderByLogDateDesc(User user);
 
-    boolean existsByUserIdAndLogDateAndDeletedFalse(Long userId, LocalDate logDate); // 하루 한 개 쓰기
+    boolean existsByUserAndLogDateAndDeletedFalse(User user, LocalDate logDate); // 하루 한 개 쓰기
 }

--- a/src/main/java/com/petfarewell/letter/repository/LetterRepository.java
+++ b/src/main/java/com/petfarewell/letter/repository/LetterRepository.java
@@ -12,5 +12,5 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
     List<Letter> findAllByIsPublicOrderByCreatedAtDesc(boolean isPublic);
     Optional<Letter> findById(Long id);
     List<Letter> findAllByUserId(Long Id);
-    long countByUserId(Long userId);
+    long countByUser(User user);
 }

--- a/src/main/java/com/petfarewell/mypage/service/MypageService.java
+++ b/src/main/java/com/petfarewell/mypage/service/MypageService.java
@@ -24,10 +24,10 @@ public class MypageService {
     @Transactional(readOnly = true)
     public UserActivitySummaryResponse getUserActivitySummary(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        long diaryCount = diaryRepository.countByUserId(user.getId());
-        long letterCount = letterRepository.countByUserId(user.getId());
+        long diaryCount = diaryRepository.countByUser(user);
+        long letterCount = letterRepository.countByUser(user);
         long tributeCount = letterTributeRepository.getTotalTributeCountByUserId(user.getId());
 
         return new UserActivitySummaryResponse(diaryCount, letterCount, tributeCount);


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #7 


  <br/>
### 🔎 Summary

- user 엔터티 연관관계 매핑이 누락되어 있어 추가했고 이에 따라, 레포지토리 및 서비스 코드 변경했습니다.
- 일기 수정 시에 needAiReflection을 비활성화한 경우 기존 공감문이 남아 있는 예외를 방지하도록 코드 변경했습니다.

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

  <br/>
### ✅ PR 체크 리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [x] test workflow가 정상적으로 작동했습니다.